### PR TITLE
Address some bit rot

### DIFF
--- a/julia_cuda/Project.toml
+++ b/julia_cuda/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 CUDAdrv = "c5f51814-7f29-56b8-a69c-e4d8f6be1fde"
 CUDAnative = "be33ccc6-a3ff-5ff2-a52e-74243cff1e17"
+CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 NVTX = "abe033e4-6c58-5f6f-85fa-ab729cab124a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/julia_cuda/backprop/backprop_cuda_kernel.jl
+++ b/julia_cuda/backprop/backprop_cuda_kernel.jl
@@ -45,6 +45,7 @@ function bpnn_layerforward_CUDA(input_cuda,
     if tx == 1
         @inbounds hidden_partial_sum[by * hid + ty] = weight_matrix[ty, tx]
     end
+    return
 end
 
 function bpnn_adjust_weights_cuda(delta, hid, ly, inp, w, oldw)
@@ -67,4 +68,5 @@ function bpnn_adjust_weights_cuda(delta, hid, ly, inp, w, oldw)
         w[index_x] += Float32(ETA * delta[index_x] + MOMENTUM * oldw[index_x])
         oldw[index_x] = Float32(ETA * delta[index_x] + MOMENTUM * oldw[index_x])
     end
+    return
 end

--- a/julia_cuda/bfs/bfs.jl
+++ b/julia_cuda/bfs/bfs.jl
@@ -38,6 +38,7 @@ function Kernel2(g_graph_mask, g_updating_graph_mask, g_graph_visited,
         g_over[1] = true
         g_updating_graph_mask[tid] = false
     end
+    return
 end
 
 function read_file(input_f)

--- a/julia_cuda/hotspot/hotspot.jl
+++ b/julia_cuda/hotspot/hotspot.jl
@@ -167,6 +167,7 @@ function calculate_temp(iteration,    # number of iteration
     if computed
         temp_dst[index + 1] = temp_t[tx, ty]
     end
+    return
 end
 
 # compute N time steps

--- a/julia_cuda/leukocyte/find_ellipse_kernel.jl
+++ b/julia_cuda/leukocyte/find_ellipse_kernel.jl
@@ -80,6 +80,7 @@ function GICOV_kernel(device_grad_x, device_grad_y, c_sin_angle, c_cos_angle, c_
     else
       @cuprintf("invalid blockid,threadid = %d,%d\n",blockIdx().x,threadIdx().x)
     end
+    return
 end
 
 
@@ -156,6 +157,7 @@ function dilate_kernel(img_dev, c_strel, dilated_out)
     end
     # Store the maximum value found
     @inbounds dilated_out[i+1,j+1] = max
+    return
 end
 
 

--- a/julia_cuda/lud/lud_kernel.jl
+++ b/julia_cuda/lud/lud_kernel.jl
@@ -37,6 +37,7 @@ function lud_diagonal(matrix, offset)
     for i = 2:BLOCK_SIZE
         @inbounds matrix[offset + tx, offset + i] = shadow[tx, i]
     end
+    return
 end
 
 function lud_perimeter(matrix, offset)
@@ -96,6 +97,7 @@ function lud_perimeter(matrix, offset)
             @inbounds matrix[offset + index, offset + blockIdx().x * BLOCK_SIZE + i] = peri_col[index, i]
         end
     end
+    return
 end
 
 function lud_internal(matrix, offset)
@@ -118,6 +120,7 @@ function lud_internal(matrix, offset)
         @inbounds sum += peri_col[i, ty] * peri_row[tx, i]
     end
     @inbounds matrix[global_col_id + tx, global_row_id + ty] -= sum
+    return
 end
 
 function lud_cuda(matrix, matrix_dim)

--- a/julia_cuda/nn/nn.jl
+++ b/julia_cuda/nn/nn.jl
@@ -33,6 +33,7 @@ function euclid(d_locations, d_distances, numRecords, lat, lng)
             CUDAnative.sqrt((lat - latLong.lat) * (lat - latLong.lat) +
                             (lng - latLong.lng) * (lng - latLong.lng))
     end
+    return
 end
 
 # This program finds the k-nearest neighbors.

--- a/julia_cuda/nw/needle_kernel.jl
+++ b/julia_cuda/nw/needle_kernel.jl
@@ -70,6 +70,7 @@ function needle_cuda_shared_1(reference, matrix_cuda, cols, penalty, i, block_wi
     for ty = 0:BLOCK_SIZE-1
         @inbounds matrix_cuda[index + ty * cols + 1] = temp[tx + 2, ty + 2]
     end
+    return
 end
 
 # FIXME: remove @inbounds (is work-around for shared memory bug)
@@ -138,4 +139,5 @@ function needle_cuda_shared_2(reference, matrix_cuda, cols, penalty, i, block_wi
     for ty = 0:BLOCK_SIZE-1
         @inbounds matrix_cuda[index + ty * cols + 1] = temp[tx + 2, ty + 2]
     end
+    return
 end

--- a/julia_cuda/particlefilter/particlefilter_double.jl
+++ b/julia_cuda/particlefilter/particlefilter_double.jl
@@ -230,6 +230,7 @@ function find_index_kernel(arrayX, arrayY, CDF, u, xj, yj, weights, Nparticles)
         yj[i] = arrayY[index]
     end
     sync_threads()
+    return
 end
 
 function normalize_weights_kernel(weights, Nparticles, partial_sums, CDF, u, seed)
@@ -266,6 +267,7 @@ function normalize_weights_kernel(weights, Nparticles, partial_sums, CDF, u, see
         u1 = shared[u1_i]
         u[i] = u1 + i / Nparticles
     end
+    return
 end
 
 function sum_kernel(partial_sums, Nparticles)
@@ -280,6 +282,7 @@ function sum_kernel(partial_sums, Nparticles)
         end
         partial_sums[1] = sum
     end
+    return
 end
 
 function likelihood_kernel(array, j, ind, objxy, likelihood, I, weights,
@@ -336,6 +339,7 @@ function likelihood_kernel(array, j, ind, objxy, likelihood, I, weights,
         partial_sums[blockIdx().x] = buffer[1]
     end
     sync_threads()
+    return
 end
 
 function getneighbors(se::Array{Int}, num_ones, neighbors::Array{Int}, radius)
@@ -439,7 +443,7 @@ function particlefilter(I::Array{UInt8}, IszX, IszY, Nfr, seed::Array{Int32}, Np
     if OUTPUT
         outf = open("output.txt", "w")
     else
-        outf = STDOUT
+        outf = stdout
     end
     println(outf,"XE: $xe")
     println(outf,"YE: $ye")

--- a/julia_cuda/particlefilter/particlefilter_naive.jl
+++ b/julia_cuda/particlefilter/particlefilter_naive.jl
@@ -388,6 +388,7 @@ function kernel_kernel(arrayX, arrayY, CDF, u, xj, yj, Nparticles)
         xj[i] = arrayX[index]
         yj[i] = arrayY[index]
     end
+    return
 end
 
 # Main

--- a/julia_cuda/pathfinder/pathfinder.jl
+++ b/julia_cuda/pathfinder/pathfinder.jl
@@ -111,6 +111,7 @@ function dynproc_kernel(iteration,
     if computed
         gpu_result[xidx] = result[tx]
     end
+    return
 end
 
 """compute N time steps"""

--- a/julia_cuda/streamcluster/streamcluster_cuda.jl
+++ b/julia_cuda/streamcluster/streamcluster_cuda.jl
@@ -55,6 +55,7 @@ function kernel_compute_cost(num, dim, x, p_w, p_a, p_c, K, stride, coord_d,
                 p_c[tid + 1] - x_cost
         end
     end
+    return
 end
 
 const g_coord_h = Ref{Vector{Float32}}()

--- a/tools/analyze.jl
+++ b/tools/analyze.jl
@@ -59,9 +59,9 @@ function analyze(host=gethostname(), dst=nothing, suite="julia_cuda")
         df = copy(df)
         for column in names(df)
             if eltype(df[column]) <: Union{Measurement, Union{Missing,<:Measurement}}
-                df[Symbol("$(column)_val")] = map(datum->ismissing(datum)?missing:datum.val,
+                df[Symbol("$(column)_val")] = map(datum->ismissing(datum) ? missing : datum.val,
                                                         df[column])
-                df[Symbol("$(column)_err")] = map(datum->ismissing(datum)?missing:datum.err,
+                df[Symbol("$(column)_err")] = map(datum->ismissing(datum) ? missing : datum.err,
                                                         df[column])
                 delete!(df, column)
             end

--- a/tools/common.jl
+++ b/tools/common.jl
@@ -1,5 +1,5 @@
 using DataFrames, CSV
-using Measurements
+using Measurements, Statistics
 
 const suites = ["cuda", "julia_cuda"]   # which benchmark suites to process
 const baseline = "cuda"

--- a/tools/measure.jl
+++ b/tools/measure.jl
@@ -36,7 +36,7 @@ function run_benchmark(dir)
 
     # read all data
     if !cmd_success
-        println(readstring(out))
+        println(read(out, String))
         error("benchmark did not succeed")
     else
         # when precompiling, an additional process will be spawned,
@@ -60,8 +60,8 @@ function run_benchmark(dir)
 end
 
 function read_data(output_path)
-    output = readlines(output_path; chomp=false)
-    any(line->contains(line, "No kernels were profiled."), output) && return nothing
+    output = readlines(output_path; keep=true)
+    any(line -> occursin("No kernels were profiled.", line), output) && return nothing
 
     # skip nvprof comments
     comments = findlast(line->occursin(r"^==\d+==", line), output)


### PR DESCRIPTION
Hi! I was trying to run the `julia_cuda` port of the Rodinia suite but ran into some bit rot, which I subsequently mended. This is a quick PR containing my (proposed) fixes.

My changes are all rather mundane. Here's a quick overview.
  * CUDAnative requires a trailing `return` statement now, so I added those wherever appropriate.
  * `mean` and `std` are now locked away in the `Statistics` package, which caused "identifier not found" errors when I tried to run `measure.jl`. I imported `Statistics`.
  * Julia's syntax for the ternary operator seems to have changed. It is now a syntax error to not have spaces around the `?`/`:` tokens. I added spaces.
  * `readstring` is now `read`.
  * `contains` is now `occursin`.
  * We are apparently no longer allowed to shout `STDOUT`. Instead, one must now whisper `stdout` to receive the standard output stream.
  * `CuArrays` is a separate package now, so I included a reference to `CuArrays` in the `Project.toml`.

Note that I didn't really go looking for bit rot, I just found it along the way as I tried to run some benchmarks. So I can't really vouch for the code that I haven't touched.